### PR TITLE
v1.1.1 - Fix parsing for Cyclops and some monsters with separate drop table tabs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'com.lootlookup'
-version = '1.1.0'
+version = '1.1.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/lootlookup/osrswiki/DropTableSection.java
+++ b/src/main/java/com/lootlookup/osrswiki/DropTableSection.java
@@ -7,9 +7,8 @@ public class DropTableSection {
     private Map<String, WikiItem[]> table;
 
     public DropTableSection() {
-        this.header = header;
-        this.table = table;
     }
+
     public DropTableSection(String header, Map<String, WikiItem[]> table) {
         this.header = header;
         this.table = table;

--- a/src/main/java/com/lootlookup/views/TableResultsPanel.java
+++ b/src/main/java/com/lootlookup/views/TableResultsPanel.java
@@ -31,6 +31,7 @@ public class TableResultsPanel extends JPanel {
     private int selectedTabIndex = 0;
 
     private final JPanel dropTableContent = new JPanel();
+    private final int maxHeaderLength = 31;
 
     public TableResultsPanel(LootLookupConfig config, DropTableSection[] dropTableSections, ViewOption viewOption, JButton collapseButton, JButton percentButton, int selectedTabIndex) {
         this.config = config;
@@ -116,10 +117,18 @@ public class TableResultsPanel extends JPanel {
             dropTableContent.add(Box.createRigidArea(new Dimension(0, 5)));
 
             JPanel labelContainer = new JPanel(new BorderLayout());
+            
+            String dropsHeaderText = selectedSection.getHeader();
+            if (dropsHeaderText.length() > maxHeaderLength) {
+                dropsHeaderText = dropsHeaderText.substring(0, maxHeaderLength) + "…";
+            }
 
-            JLabel sectionHeaderLabel = new JLabel(selectedSection.getHeader());
+            JLabel sectionHeaderLabel = new JLabel(dropsHeaderText);
             sectionHeaderLabel.setFont(FontManager.getRunescapeBoldFont());
             sectionHeaderLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+            if (dropsHeaderText.endsWith("…")) {
+                sectionHeaderLabel.setToolTipText(selectedSection.getHeader());
+            }
 
             labelContainer.add(sectionHeaderLabel, BorderLayout.WEST);
             dropTableContent.add(labelContainer);


### PR DESCRIPTION
v1.1.1

* Fix parsing for OSRS Wiki page [Cyclops](https://oldschool.runescape.wiki/w/Cyclops); handle as an edge case
* Fix parsing for some monsters with separate drop table tabs;  if the last heading on the page was a "drops" heading, the tab would not display