### PR TITLE
Fix alignment of price text

### DIFF
--- a/src/main/java/com/lootlookup/views/WikiItemPanel.java
+++ b/src/main/java/com/lootlookup/views/WikiItemPanel.java
@@ -203,6 +203,7 @@ public class WikiItemPanel extends JPanel {
 
         setPriceLabelText();
         priceLabel.setVerticalAlignment(JLabel.CENTER);
+        priceLabel.setHorizontalAlignment(JLabel.RIGHT);
 
 
         rightSidePanel.add(quantityLabel);


### PR DESCRIPTION
Hey, only just noticed this. Hopefully I got this to you soon enough. Sometimes the item quantity text would have too many characters, and the price text below it would not appear to be right-aligned in the panel. This fixes that.

Sorry for another PR!